### PR TITLE
Updates the method used to get sites.

### DIFF
--- a/ACF 5.2.7 and newer/acf-relationship-multisite-v5.php
+++ b/ACF 5.2.7 and newer/acf-relationship-multisite-v5.php
@@ -925,10 +925,10 @@ class acf_field_relationship_multisite extends acf_field {
 	function acf_get_sites() {
 
 		$ref = array();
-		$sites = wp_get_sites();
+		$sites = get_sites();
 		foreach ($sites as $site) {
-			$current_blog_details = get_blog_details( array( 'blog_id' => $site['blog_id'] ) );
-			$site_id = $site['blog_id'];
+			$current_blog_details = get_blog_details( array( 'blog_id' => $site->blog_id ) );
+			$site_id = $site->blog_id;
 			$label = $current_blog_details->blogname;
 			$ref[$site_id] = $label;
 		}


### PR DESCRIPTION
As of 4.6 wp_get_sites() was deprecated, so this future proofs that.

I'm aware this plugin is no longer developed but it's a quick (and working) fix :) hopefully it gets merged.